### PR TITLE
Add standalone and embedded viewer modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ vite.config.ts.timestamp-*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Viewer scratch report
+/.viewer-report.json
+/reports/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Reach for this when you already use Playwright with `@axe-core/playwright`, but 
 - Formatter utilities for converting axe results into the beta schema.
 - A static custom element viewer exported as `@schalkneethling/axe-aggregate-reporter/viewer`.
 - A CSS file exported as `@schalkneethling/axe-aggregate-reporter/viewer.css`.
+- A viewer CLI for local review and standalone HTML export.
 - Deterministic local fixture tests for the reporter/viewer path.
 
 ## Install
@@ -91,6 +92,45 @@ The reporter writes `full-report.json` in the Playwright root directory.
 
 ## Viewer setup
 
+For local review, use the packaged viewer command from the project where your
+report was generated:
+
+```sh
+pnpm exec axe-aggregate-viewer ./full-report.json
+```
+
+When working in this repository, the equivalent local script is:
+
+```sh
+pnpm viewer ./path/to/full-report.json
+```
+
+The command copies the target report to an ignored `.viewer-report.json` scratch
+file in the viewer package, starts a local static server, and opens the viewer in
+your browser. Use `--port 4173` to choose a port or `--no-open` to leave browser
+opening to you.
+
+To create a self-contained HTML report for short-lived sharing services such as
+[Ephemeral Pages](https://ephemeral.schalkneethling.com/), export a standalone
+viewer:
+
+```sh
+pnpm exec axe-aggregate-viewer ./full-report.json --standalone
+```
+
+By default, the command writes the standalone page to the gitignored
+`reports/axe-aggregate-report.html` file. Pass a path after `--standalone` to
+choose a different output file:
+
+```sh
+pnpm exec axe-aggregate-viewer ./full-report.json --standalone reports/team-report.html
+```
+
+The standalone report inlines the viewer CSS, JavaScript, icons, and report JSON.
+The report data is embedded in an inert
+`<script type="application/json">` block, so the page does not need to fetch any
+external files.
+
 Use the custom element on any static page that can fetch the generated JSON file:
 
 ```html
@@ -108,6 +148,31 @@ Use the custom element on any static page that can fetch the generated JSON file
   </body>
 </html>
 ```
+
+For a standalone page, embed the report data in the DOM and point the viewer at
+that script:
+
+```html
+<axe-aggregate-reporter data-script="axe-aggregate-report-data"></axe-aggregate-reporter>
+<script id="axe-aggregate-report-data" type="application/json">
+  []
+</script>
+```
+
+When the viewer page does not set a `src` attribute, it loads
+`./full-report.json` by default. You can also point the packaged viewer at any
+report URL the page can fetch with a query string:
+
+```txt
+index.html?src=http://localhost:4173/full-report.json
+index.html?report=./reports/full-report.json
+```
+
+Browsers cannot fetch arbitrary filesystem paths such as
+`/Users/me/project/full-report.json` from a static page unless that path is
+served over HTTP or selected through a browser file picker. For local project
+reports, run a small static server in the project that generated the report and
+pass that URL to the viewer.
 
 The viewer supports loading, empty, invalid report, and fetch-error states. It renders a summary, test-level sections, failed and passed checks, impact labels, node targets, check messages, and Deque help links.
 
@@ -141,6 +206,8 @@ All project CSS should use logical properties and values. Keep declarations alph
 ```sh
 pnpm run build:ts
 pnpm run lint:eslint
+pnpm viewer ./full-report.json
+pnpm viewer ./full-report.json --standalone
 pnpm run test:unit
 pnpm run test:e2e
 pnpm test

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ When working in this repository, the equivalent local script is:
 pnpm viewer ./path/to/full-report.json
 ```
 
-The command copies the target report to an ignored `.viewer-report.json` scratch
-file in the viewer package, starts a local static server, and opens the viewer in
-your browser. Use `--port 4173` to choose a port or `--no-open` to leave browser
-opening to you.
+The command copies the target report to an ignored `/.viewer-report.json`
+scratch file at the package root, starts a local static server, and opens the
+viewer in your browser. Use `--port 4173` to choose a port or `--no-open` to
+leave browser opening to you.
 
 To create a self-contained HTML report for short-lived sharing services such as
 [Ephemeral Pages](https://ephemeral.schalkneethling.com/), export a standalone

--- a/bin/axe-aggregate-viewer.js
+++ b/bin/axe-aggregate-viewer.js
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+const scratchReport = ".viewer-report.json";
+const embeddedReportId = "axe-aggregate-report-data";
+const defaultPort = 4173;
+const defaultStandalonePath = path.join("reports", "axe-aggregate-report.html");
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".ico", "image/x-icon"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml; charset=utf-8"],
+  [".webmanifest", "application/manifest+json; charset=utf-8"],
+]);
+
+function getOptions(argv) {
+  const options = {
+    open: true,
+    port: defaultPort,
+    reportPath: null,
+    standalonePath: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === "--no-open") {
+      options.open = false;
+      continue;
+    }
+
+    if (arg === "--standalone" || arg === "-s") {
+      const value = argv[index + 1];
+
+      options.standalonePath =
+        value && !value.startsWith("-") ? value : defaultStandalonePath;
+
+      if (value && !value.startsWith("-")) {
+        index += 1;
+      }
+
+      continue;
+    }
+
+    if (arg.startsWith("--standalone=")) {
+      options.standalonePath =
+        arg.slice("--standalone=".length) || defaultStandalonePath;
+      continue;
+    }
+
+    if (arg === "--port" || arg === "-p") {
+      const value = argv[index + 1];
+
+      if (!value) {
+        throw new Error(`${arg} requires a port number.`);
+      }
+
+      options.port = Number.parseInt(value, 10);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--port=")) {
+      options.port = Number.parseInt(arg.slice("--port=".length), 10);
+      continue;
+    }
+
+    if (!options.reportPath) {
+      options.reportPath = arg;
+      continue;
+    }
+
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+
+  if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535) {
+    throw new Error("Port must be a number between 1 and 65535.");
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.info(`Usage:
+  axe-aggregate-viewer <path-to-full-report.json> [--port 4173] [--no-open]
+  axe-aggregate-viewer <path-to-full-report.json> --standalone [report.html]
+
+Copies the target report to ${scratchReport}, starts a local viewer server, and
+opens the viewer in your browser.
+
+With --standalone, writes a self-contained HTML file with inlined CSS,
+JavaScript, and report JSON. The default standalone output is
+${defaultStandalonePath}.`);
+}
+
+async function readReport(reportPath) {
+  const source = path.resolve(process.cwd(), reportPath);
+  const rawReport = await fs.readFile(source, "utf-8");
+  const report = JSON.parse(rawReport);
+
+  if (!Array.isArray(report)) {
+    throw new Error("The report must be a top-level array.");
+  }
+
+  return { rawReport, source };
+}
+
+async function copyReport(reportPath) {
+  const destination = path.join(rootDir, scratchReport);
+  const { rawReport, source } = await readReport(reportPath);
+
+  await fs.writeFile(destination, rawReport);
+
+  return { destination, source };
+}
+
+function escapeJsonForHtml(rawReport) {
+  return rawReport.replaceAll("</script", "<\\/script");
+}
+
+function stripModuleImport(source) {
+  return source.replace('import { createIcon } from "./lucide-icons.js";\n\n', "");
+}
+
+function stripIconExport(source) {
+  return source.replace("export const createIcon", "const createIcon");
+}
+
+async function writeStandaloneReport(reportPath, outputPath) {
+  const { rawReport, source } = await readReport(reportPath);
+  const destination = path.resolve(process.cwd(), outputPath);
+  const [css, icons, viewer] = await Promise.all([
+    fs.readFile(path.join(rootDir, "css", "axe-aggregate-reporter.css"), "utf-8"),
+    fs.readFile(path.join(rootDir, "js", "lucide-icons.js"), "utf-8"),
+    fs.readFile(path.join(rootDir, "js", "axe-aggregate-reporter.js"), "utf-8"),
+  ]);
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Accessibility report</title>
+    <style>
+${css}
+    </style>
+  </head>
+  <body>
+    <axe-aggregate-reporter data-script="${embeddedReportId}"></axe-aggregate-reporter>
+    <script id="${embeddedReportId}" type="application/json">
+${escapeJsonForHtml(rawReport)}
+    </script>
+    <script type="module">
+${stripIconExport(icons)}
+
+${stripModuleImport(viewer)}
+    </script>
+  </body>
+</html>
+`;
+
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.writeFile(destination, html);
+
+  return { destination, source };
+}
+
+function getFilePath(requestUrl) {
+  const url = new URL(requestUrl, `http://127.0.0.1:${defaultPort}`);
+  const pathname = decodeURIComponent(url.pathname);
+  const requestedPath = pathname === "/" ? "/index.html" : pathname;
+  const filePath = path.normalize(path.join(rootDir, requestedPath));
+
+  if (filePath !== rootDir && !filePath.startsWith(`${rootDir}${path.sep}`)) {
+    return null;
+  }
+
+  return filePath;
+}
+
+function createServer() {
+  return http.createServer(async (request, response) => {
+    const filePath = getFilePath(request.url ?? "/");
+
+    if (!filePath) {
+      response.writeHead(403);
+      response.end("Forbidden");
+      return;
+    }
+
+    try {
+      const stat = await fs.stat(filePath);
+
+      if (!stat.isFile()) {
+        response.writeHead(404);
+        response.end("Not found");
+        return;
+      }
+
+      response.writeHead(200, {
+        "Content-Length": stat.size,
+        "Content-Type": contentTypes.get(path.extname(filePath)) ?? "application/octet-stream",
+      });
+      createReadStream(filePath).pipe(response);
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        response.writeHead(404);
+        response.end("Not found");
+        return;
+      }
+
+      response.writeHead(500);
+      response.end("Server error");
+    }
+  });
+}
+
+function openBrowser(url) {
+  const command =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "cmd"
+        : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  const child = spawn(command, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+
+  child.unref();
+}
+
+async function main() {
+  const options = getOptions(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  if (!options.reportPath) {
+    printHelp();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.standalonePath) {
+    const { destination, source } = await writeStandaloneReport(
+      options.reportPath,
+      options.standalonePath,
+    );
+
+    console.info(`Read report from ${source}`);
+    console.info(`Wrote standalone viewer to ${destination}`);
+    return;
+  }
+
+  const { destination, source } = await copyReport(options.reportPath);
+  const server = createServer();
+
+  server.on("error", (error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+  server.listen(options.port, "127.0.0.1", () => {
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : options.port;
+    const viewerUrl = `http://127.0.0.1:${port}/?src=./${scratchReport}`;
+
+    console.info(`Copied report from ${source}`);
+    console.info(`Viewer report scratch file: ${destination}`);
+    console.info(`Viewer: ${viewerUrl}`);
+    console.info("Press Ctrl+C to stop the server.");
+
+    if (options.open) {
+      openBrowser(viewerUrl);
+    }
+  });
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/bin/axe-aggregate-viewer.js
+++ b/bin/axe-aggregate-viewer.js
@@ -131,7 +131,7 @@ async function copyReport(reportPath) {
 }
 
 function escapeJsonForHtml(rawReport) {
-  return rawReport.replaceAll("</script", "<\\/script");
+  return rawReport.replaceAll(/<\/script/gi, "<\\/script");
 }
 
 function stripModuleImport(source) {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   </head>
 
   <body>
-    <axe-aggregate-reporter src="./full-report.json"></axe-aggregate-reporter>
+    <axe-aggregate-reporter></axe-aggregate-reporter>
     <script src="./js/axe-aggregate-reporter.js" type="module"></script>
   </body>
 </html>

--- a/js/axe-aggregate-reporter.js
+++ b/js/axe-aggregate-reporter.js
@@ -40,10 +40,10 @@ class AxeAggregateReporter extends HTMLElement {
     this.#renderState("Loading accessibility report...");
 
     try {
-      const embeddedReport = this.#getEmbeddedReport();
+      const hasEmbeddedReport = this.hasAttribute("data-script");
 
-      if (embeddedReport) {
-        this.#setReport(embeddedReport);
+      if (hasEmbeddedReport) {
+        this.#setReport(this.#getEmbeddedReport());
         return;
       }
 

--- a/js/axe-aggregate-reporter.js
+++ b/js/axe-aggregate-reporter.js
@@ -10,8 +10,10 @@ const impactLabels = {
   unknown: "Unknown impact",
 };
 
+const defaultReportSrc = "./full-report.json";
+
 class AxeAggregateReporter extends HTMLElement {
-  static observedAttributes = ["src"];
+  static observedAttributes = ["data-script", "src"];
 
   #filters = {
     impact: "all",
@@ -25,31 +27,34 @@ class AxeAggregateReporter extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    if (name === "src" && oldValue !== newValue && this.isConnected) {
+    if (
+      (name === "data-script" || name === "src") &&
+      oldValue !== newValue &&
+      this.isConnected
+    ) {
       void this.#loadReport();
     }
   }
 
   async #loadReport() {
-    const src = this.getAttribute("src") ?? "./full-report.json";
-
     this.#renderState("Loading accessibility report...");
 
     try {
+      const embeddedReport = this.#getEmbeddedReport();
+
+      if (embeddedReport) {
+        this.#setReport(embeddedReport);
+        return;
+      }
+
+      const src = this.getAttribute("src") ?? this.#getReportSrcFromUrl();
       const response = await fetch(src);
 
       if (!response.ok) {
         throw new Error(`The report request failed with ${response.status}.`);
       }
 
-      const report = await response.json();
-
-      if (!Array.isArray(report)) {
-        throw new Error("The report must be a top-level array.");
-      }
-
-      this.#report = report;
-      this.#renderReport();
+      this.#setReport(await response.json());
     } catch (error) {
       this.#renderState(
         error instanceof Error
@@ -57,6 +62,37 @@ class AxeAggregateReporter extends HTMLElement {
           : "Unable to load report.",
       );
     }
+  }
+
+  #getEmbeddedReport() {
+    const scriptId = this.getAttribute("data-script");
+
+    if (!scriptId) {
+      return null;
+    }
+
+    const script = document.getElementById(scriptId);
+
+    if (!script) {
+      throw new Error(`Unable to find embedded report script "${scriptId}".`);
+    }
+
+    return JSON.parse(script.textContent ?? "");
+  }
+
+  #getReportSrcFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+
+    return params.get("src") ?? params.get("report") ?? defaultReportSrc;
+  }
+
+  #setReport(report) {
+    if (!Array.isArray(report)) {
+      throw new Error("The report must be a top-level array.");
+    }
+
+    this.#report = report;
+    this.#renderReport();
   }
 
   #createElement(tagName, className, textContent) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/axe-aggregate-reporter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Aggregate Playwright axe accessibility results into a stable JSON report and static viewer.",
   "packageManager": "pnpm@10.33.2",
   "engines": {
@@ -8,6 +8,9 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "axe-aggregate-viewer": "./bin/axe-aggregate-viewer.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -22,6 +25,7 @@
     "./viewer.css": "./css/axe-aggregate-reporter.css"
   },
   "files": [
+    "bin/axe-aggregate-viewer.js",
     "css/axe-aggregate-reporter.css",
     "dist",
     "js/axe-aggregate-reporter.js",
@@ -31,6 +35,7 @@
   ],
   "scripts": {
     "test": "pnpm run build:ts && pnpm run lint:eslint && pnpm run test:unit && pnpm run test:e2e",
+    "viewer": "node ./bin/axe-aggregate-viewer.js",
     "dependencies:review": "multiocular",
     "prettier:lint": "prettier --check .",
     "prettier:format": "prettier --write .",

--- a/tests/viewer-cli.test.ts
+++ b/tests/viewer-cli.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+test("writes a standalone viewer with embedded report JSON", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "axe-viewer-"));
+  const reportPath = path.join(tempDir, "full-report.json");
+  const outputPath = path.join(tempDir, "report.html");
+  const report = [
+    {
+      testId: "embedded-script",
+      title: "Embedded script escaping",
+      status: "failed",
+      axe: {
+        url: "https://example.com",
+        failed: [
+          {
+            id: "script-data",
+            impact: "serious",
+            tags: ["wcag2a"],
+            description: "Avoid closing script tags in embedded JSON",
+            help: "Embedded JSON remains inert",
+            helpUrl: "https://dequeuniversity.com/",
+            nodes: [
+              {
+                html: "</script><p>Still JSON</p>",
+                target: ["body"],
+                checks: [
+                  {
+                    id: "script-data",
+                    impact: "serious",
+                    message: "The JSON string must not close the script tag",
+                  },
+                ],
+              },
+            ],
+            totalNodes: 1,
+          },
+        ],
+        passed: [],
+      },
+    },
+  ];
+
+  await fs.writeFile(reportPath, JSON.stringify(report, null, 2));
+  await execFileAsync("node", [
+    "./bin/axe-aggregate-viewer.js",
+    reportPath,
+    "--standalone",
+    outputPath,
+  ]);
+
+  const html = await fs.readFile(outputPath, "utf-8");
+
+  expect(html).toContain(
+    '<axe-aggregate-reporter data-script="axe-aggregate-report-data"></axe-aggregate-reporter>',
+  );
+  expect(html).toContain('type="application/json"');
+  expect(html).toContain("<\\/script><p>Still JSON</p>");
+  expect(html).toContain("customElements.define");
+  expect(html).toContain("const createIcon");
+  expect(html).not.toContain('import { createIcon } from "./lucide-icons.js";');
+  expect(html).not.toContain("export const createIcon");
+});
+
+test("writes standalone viewer to the reports directory by default", async () => {
+  const reportPath = path.resolve("tests/fixtures/sample-report.json");
+  const outputPath = path.resolve("reports/axe-aggregate-report.html");
+
+  await fs.rm(outputPath, { force: true });
+  await execFileAsync("node", [
+    "./bin/axe-aggregate-viewer.js",
+    reportPath,
+    "--standalone",
+  ]);
+
+  const html = await fs.readFile(outputPath, "utf-8");
+
+  expect(html).toContain(
+    '<axe-aggregate-reporter data-script="axe-aggregate-report-data"></axe-aggregate-reporter>',
+  );
+});

--- a/tests/viewer-cli.test.ts
+++ b/tests/viewer-cli.test.ts
@@ -28,7 +28,7 @@ test("writes a standalone viewer with embedded report JSON", async () => {
             helpUrl: "https://dequeuniversity.com/",
             nodes: [
               {
-                html: "</script><p>Still JSON</p>",
+                html: "</SCRIPT><p>Still JSON</p>",
                 target: ["body"],
                 checks: [
                   {

--- a/tests/viewer.spec.ts
+++ b/tests/viewer.spec.ts
@@ -54,3 +54,84 @@ test("renders the static accessibility report viewer", async ({ page }) => {
   await expect(page.locator("details.node-disclosure")).toHaveCount(1);
   await expect(page.getByRole("link", { name: /Deque guidance/ })).toBeVisible();
 });
+
+test("loads a report URL from the page query string", async ({ page }) => {
+  const css = await fs.readFile("css/axe-aggregate-reporter.css", "utf-8");
+  const icons = (await fs.readFile("js/lucide-icons.js", "utf-8")).replace(
+    "export const createIcon",
+    "const createIcon",
+  );
+  const reporter = (
+    await fs.readFile("js/axe-aggregate-reporter.js", "utf-8")
+  ).replace('import { createIcon } from "./lucide-icons.js";\n\n', "");
+  const report = await fs.readFile(
+    "tests/fixtures/sample-report.json",
+    "utf-8",
+  );
+
+  await page.route("https://reports.test/project/full-report.json", async (route) => {
+    await route.fulfill({
+      body: report,
+      contentType: "application/json",
+    });
+  });
+  await page.route("https://viewer.test/**", async (route) => {
+    await route.fulfill({
+      body: `
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <title>Report viewer</title>
+        <style>${css}</style>
+      </head>
+      <body>
+        <axe-aggregate-reporter></axe-aggregate-reporter>
+        <script type="module">${icons}${reporter}</script>
+      </body>
+    </html>
+  `,
+      contentType: "text/html",
+    });
+  });
+  await page.goto(
+    "https://viewer.test/?src=https%3A%2F%2Freports.test%2Fproject%2Ffull-report.json",
+  );
+
+  await expect(
+    page.getByRole("heading", { name: "Sample failing page" }),
+  ).toBeVisible();
+});
+
+test("renders embedded report JSON from an inert script", async ({ page }) => {
+  const css = await fs.readFile("css/axe-aggregate-reporter.css", "utf-8");
+  const icons = (await fs.readFile("js/lucide-icons.js", "utf-8")).replace(
+    "export const createIcon",
+    "const createIcon",
+  );
+  const reporter = (
+    await fs.readFile("js/axe-aggregate-reporter.js", "utf-8")
+  ).replace('import { createIcon } from "./lucide-icons.js";\n\n', "");
+  const report = await fs.readFile(
+    "tests/fixtures/sample-report.json",
+    "utf-8",
+  );
+
+  await page.setContent(`
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <title>Report viewer</title>
+        <style>${css}</style>
+      </head>
+      <body>
+        <axe-aggregate-reporter data-script="report-data"></axe-aggregate-reporter>
+        <script id="report-data" type="application/json">${report}</script>
+        <script type="module">${icons}${reporter}</script>
+      </body>
+    </html>
+  `);
+
+  await expect(
+    page.getByRole("heading", { name: "Sample failing page" }),
+  ).toBeVisible();
+});

--- a/tests/viewer.spec.ts
+++ b/tests/viewer.spec.ts
@@ -135,3 +135,38 @@ test("renders embedded report JSON from an inert script", async ({ page }) => {
     page.getByRole("heading", { name: "Sample failing page" }),
   ).toBeVisible();
 });
+
+test("treats embedded report JSON as authoritative when it is invalid", async ({ page }) => {
+  const css = await fs.readFile("css/axe-aggregate-reporter.css", "utf-8");
+  const icons = (await fs.readFile("js/lucide-icons.js", "utf-8")).replace(
+    "export const createIcon",
+    "const createIcon",
+  );
+  const reporter = (
+    await fs.readFile("js/axe-aggregate-reporter.js", "utf-8")
+  ).replace('import { createIcon } from "./lucide-icons.js";\n\n', "");
+
+  await page.setContent(`
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <title>Report viewer</title>
+        <style>${css}</style>
+      </head>
+      <body>
+        <axe-aggregate-reporter
+          data-script="report-data"
+          src="missing.json"
+        ></axe-aggregate-reporter>
+        <script id="report-data" type="application/json">false</script>
+        <script type="module">${icons}${reporter}</script>
+      </body>
+    </html>
+  `);
+
+  await expect(
+    page.getByText(
+      "Unable to load report. The report must be a top-level array.",
+    ),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Add a viewer CLI for local review and standalone HTML export
- Support embedded report JSON in the custom element for self-contained Ephemeral Pages hosting
- Default standalone output to a gitignored `reports/` location and document the workflow
- Bump the package version to `0.6.0` and include the new CLI in the published package

## Testing
- Added unit coverage for standalone HTML generation and default project-local output
- Added Playwright coverage for query-string loading and embedded JSON rendering
- Verified typecheck, unit tests, package dry-run, and local viewer/export flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a CLI viewer for local report viewing and standalone HTML export capability.
  * Added support for embedding report data via JSON script elements.

* **Documentation**
  * Updated with comprehensive viewer setup instructions and CLI command examples.
  * Documented query parameter support for remote report loading and standalone output behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/axe-aggregate-reporter/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->