### PR TITLE
Add checkout step to the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,11 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Summary
- Add a checkout step to the `publish` job so `actions/setup-node` can resolve `package.json` before publishing
- Keep the release-triggered npm publish flow intact while fixing the missing workspace context in the final job

## Testing
- Not run (workflow-only change)
- Verified the workflow now checks out the repository before `setup-node`