### PR TITLE
Ship viewer static assets in the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/axe-aggregate-reporter",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Aggregate Playwright axe accessibility results into a stable JSON report and static viewer.",
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -25,13 +25,21 @@
     "./viewer.css": "./css/axe-aggregate-reporter.css"
   },
   "files": [
+    "apple-touch-icon.png",
     "bin/axe-aggregate-viewer.js",
     "css/axe-aggregate-reporter.css",
     "dist",
+    "favicon.ico",
+    "favicon.svg",
+    "favicon-96x96.png",
+    "index.html",
     "js/axe-aggregate-reporter.js",
     "js/lucide-icons.js",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "site.webmanifest",
+    "web-app-manifest-192x192.png",
+    "web-app-manifest-512x512.png"
   ],
   "scripts": {
     "test": "pnpm run build:ts && pnpm run lint:eslint && pnpm run test:unit && pnpm run test:e2e",

--- a/tests/viewer-cli.test.ts
+++ b/tests/viewer-cli.test.ts
@@ -7,6 +7,19 @@ import { expect, test } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
+test("packages the static viewer files used by the CLI server", async () => {
+  const { stdout } = await execFileAsync("npm", ["pack", "--dry-run", "--json"]);
+  const [packResult] = JSON.parse(stdout);
+  const packageFiles = new Set(packResult.files.map((file) => file.path));
+
+  expect(packageFiles.has("index.html")).toBe(true);
+  expect(packageFiles.has("css/axe-aggregate-reporter.css")).toBe(true);
+  expect(packageFiles.has("js/axe-aggregate-reporter.js")).toBe(true);
+  expect(packageFiles.has("js/lucide-icons.js")).toBe(true);
+  expect(packageFiles.has("site.webmanifest")).toBe(true);
+  expect(packageFiles.has("favicon.svg")).toBe(true);
+});
+
 test("writes a standalone viewer with embedded report JSON", async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "axe-viewer-"));
   const reportPath = path.join(tempDir, "full-report.json");


### PR DESCRIPTION
## Summary
- Include the viewer entry HTML and required static assets in the package `files` list so the CLI server can serve the viewer from an installed package.
- Add a regression test that inspects the packed tarball and verifies the viewer files are present.

## Testing
- `pnpm run test:unit`